### PR TITLE
Fix spelling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
     "version": "2.0~ynh4",
     "license": "Beerware",
     "maintainer": {
-        "name": "krakinou",
+        "name": "Krakinou",
         "email": "misterl56@hotmail.com"
     },
         "requirements": {


### PR DESCRIPTION
to be the same as https://github.com/YunoHost-Apps/calibreweb_ynh/blob/master/manifest.json