### PR TITLE
Fix #10: fix the owner of cron file

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -131,6 +131,7 @@ newaliases
 
 #adding cronjob for removing expired email addresses
 cp -a ../conf/$app.cron /etc/cron.d/$app
+chown root:root /etc/cron.d/$app
 chmod 644 /etc/cron.d/$app
 
 # Create a dedicated nginx config


### PR DESCRIPTION
Yunohost does a `chown -R admin` to the app files it cloned, so we need to set the owner back to root once we installed the cron script in `/etc/cron.d`